### PR TITLE
Added camera reference

### DIFF
--- a/src/content/g101/3D/101_3d_07.md
+++ b/src/content/g101/3D/101_3d_07.md
@@ -29,6 +29,8 @@ Much of the code for movement is the same as we used for the third-person charac
 ```gdscript
 extends KinematicBody
 
+onready var camera = $Pivot/Camera
+
 var gravity = -30
 var max_speed = 8
 var mouse_sensitivity = 0.002  # radians/pixel


### PR DESCRIPTION
Just a quick fix for some differences in the video and the text. The text version's code doesn't show the camera variable declaration, but it does get used in the get_input() function