### PR TITLE
Update `path_follow.md` to include `velocity` declaration

### DIFF
--- a/src/content/ai/path_follow.md
+++ b/src/content/ai/path_follow.md
@@ -36,6 +36,7 @@ var move_speed = 100
 export (NodePath) var patrol_path
 var patrol_points
 var patrol_index = 0
+var velocity = Vector2.ZERO
 
 func _ready():
     if patrol_path:


### PR DESCRIPTION
The `_physics_process()` function detailed in this recipe will throw an error because `velocity` is not declared. I have a friend who is beginner and was confused by this example.

Alternatively, it could be declared in the second example if you think that's more clear:
```
var velocity = (target - position).normalized() * move_speed
velocity = move_and_slide(velocity)
```