### PR TITLE
Update 2d_shooting.md

### DIFF
--- a/src/content/2D/2d_shooting.md
+++ b/src/content/2D/2d_shooting.md
@@ -60,7 +60,7 @@ This will work for any character type, not just the "rotate-and-move" style show
 In the character's script we add a variable to hold the bullet scene for instancing:
 
 ```gdscript
-export (PackedScene) var Bullet
+export (PackedScene) var Bullet = preload("res://2DExample/Bullet.tscn")
 ```
 
 And check for our defined input action:


### PR DESCRIPTION
add default value for "Bullet" variable

"export" variable allow user to change value tough the Godot "scene editor".
But this tutorial don't talk about this subject, and some people was asking question in comment about this subject.

I propose this pull request to define a default value for the "Bullet scene"