### PR TITLE
Fix Circle spawn in Mobile Game: Circle Jump

### DIFF
--- a/src/content/games/circle_jump/circle_jump_02.md
+++ b/src/content/games/circle_jump/circle_jump_02.md
@@ -87,7 +87,7 @@ func spawn_circle(_position=null):
     if !_position:
         var x = rand_range(-150, 150)
         var y = rand_range(-500, -400)
-        c.position = player.target.position + Vector2(x, y)
+        _position = player.target.position + Vector2(x, y)
     add_child(c)
     c.init(_position)
 ```


### PR DESCRIPTION
First of all, thank you for such a wonderful guide, it's been very fun to follow and play with it.

I've noticed a crash when folowing the text guide so wanted to propose a fix that is also [shown in the video](https://youtu.be/ahsFSeDbG84?t=359) :

Since the `init` function in the Circle is called with the given `_position`, the function should update the `_position` variable when null and not the circle one.

Cheers!