### PR TITLE
Add a notice as the kenney asset imports centered now

### DIFF
--- a/src-3/content/g101/3D/101_3d_02.md
+++ b/src-3/content/g101/3D/101_3d_02.md
@@ -60,6 +60,12 @@ problem: it seems Kenney exported this model with an offset:
 
 ![alt](/godot_recipes/3.x/img/3d_02_02.png)
 
+{{% notice tip %}}
+If you've downloaded a recent version of the platformer kit, you won't need to 
+correct the translation. It looks like Kenney has corrected the offset and it 
+will be centered upon import.
+{{% /notice %}}
+
 It would much better if the crate were centered relative to the parent node, so
 that when the `RigidBody` rotates about its center, so will the mesh. To fix
 this, select the `MeshInstance` node and set its _Translation_ property to


### PR DESCRIPTION
Originally thought to delete the paragraph, but it is still a nice beginner section on how to adjust offset :)

_*Didn't add the iframe change - not sure why it shows up as a diff_