### PR TITLE
Fix broken link to platform character in spritesheet animation

### DIFF
--- a/src-4/content/animation/spritesheet_animation.md
+++ b/src-4/content/animation/spritesheet_animation.md
@@ -61,5 +61,5 @@ Feel free to add the other animations yourself. For example, the "jump" animatio
 ## Related recipes
 
 <!-- - [Top-down character](http://kidscancode.org/godot_recipes/2d/topdown_movement/#option-1-8-way-movement) -->
-- [Platform character](http://kidscancode.org/godot_recipes/2d/platform_character/)
+- [Platform character](/godot_recipes/4.x/2d/platform_character/)
 <!-- - [Controlling animation states](http://kidscancode.org/godot_recipes/animation/animation_state_machine/) -->


### PR DESCRIPTION
Fixes the link in the following page which is broken

https://kidscancode.org/godot_recipes/4.x/animation/spritesheet_animation/index.html